### PR TITLE
Revert "Enabled ril-daemons"

### DIFF
--- a/rootdir/root/init.qcom.rc
+++ b/rootdir/root/init.qcom.rc
@@ -457,6 +457,7 @@ service qmuxd /system/bin/qmuxd
     class main
     user radio
     group radio audio bluetooth gps qcom_diag
+    disabled
 
 service netmgrd /system/bin/netmgrd
     class main
@@ -677,6 +678,7 @@ service ril-daemon2 /system/bin/rild -c 2
     socket rild2 stream 660 root radio
     socket rild-debug2 stream 660 radio system
     user root
+    disabled
     group radio cache inet misc audio sdcard_r sdcard_rw diag qcom_diag log
 
 service ril-daemon3 /system/bin/rild -c 3


### PR DESCRIPTION
This reverts commit 1bdf0bcba607eb65b666c0b6c334aacc96d48df8. The daemons
are now started by init.class_main.sh script as in Android, as now we have
a correct PATH in the environment.