### PR TITLE
Enable wcnss service from fp-open and clean up init_wlan

### DIFF
--- a/FP2.mk
+++ b/FP2.mk
@@ -68,7 +68,7 @@ PRODUCT_PACKAGES += \
     wpa_supplicant_overlay.conf \
     p2p_supplicant_overlay.conf
 
-PRODUCT_PACKAGES += wcnss_service
+#PRODUCT_PACKAGES += wcnss_service
 
 #ANT stack
 PRODUCT_PACKAGES += \

--- a/rootdir/root/init.target.rc
+++ b/rootdir/root/init.target.rc
@@ -109,6 +109,12 @@ service init_wlan /system/bin/sh /system/etc/init_wlan.sh
     group root
     oneshot
 
+service wcnss-service /system/bin/wcnss_service
+    class main
+    user root
+    group root
+    oneshot
+
 service init_bt /system/bin/sh /init_bt.sh
     class main
     user root

--- a/rootdir/root/init_wlan.sh
+++ b/rootdir/root/init_wlan.sh
@@ -1,28 +1,13 @@
 #!/system/bin/sh
 
-# The Ubports project
+## The Ubports project
+## Wait for WCNSS service to setup WLAN device over QMI
 
-# Workaround for conn_init not copying the updated firmware
-rm /data/misc/wifi/WCNSS_qcom_cfg.ini
-rm /data/misc/wifi/WCNSS_qcom_wlan_nv.bin
-
-/system/bin/conn_init
-
-echo 1 > /dev/wcnss_wlan
-
-for i in 1 2 3; do
-    # sleep first to avoid issue when called after conn_init
-    sleep 1
-    if [ ! -f /sys/devices/platform/wcnss_wlan.0/net/wlan0/address ]; then
+while true; do
+    sleep 2
+    if [ ! -f /sys/devices/fb000000.qcom,wcnss-wlan/net/wlan0/address ]; then
         echo sta > /sys/module/wlan/parameters/fwpath
     else
         break
     fi
 done
-
-if [ ! -f /sys/devices/platform/wcnss_wlan.0/net/wlan0/address ]; then
-    # Driver is in a broken state, give it a few seconds and try to reload
-    echo 1 > /dev/wcnss_wlan
-    sleep 2
-    echo sta > /sys/module/wlan/parameters/fwpath
-fi


### PR DESCRIPTION
Re-enable previously removed wcnss_service now that we are using the correct one that supports qmi to obtain the MAC address and issue commands. Also clean up init_wlan so that the driver is unblocked correctly.