### PR TITLE
Set FP2 scale factor to match Nexus 5

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -144,3 +144,6 @@ audio.offload.gapless.enabled=false
 
 #enable dsds
 persist.radio.multisim.config=dsds
+
+# UT: set scale factor to be in line with other similarly sized devices
+ro.sf.lcd_density=480


### PR DESCRIPTION
The ro.sf.lcd_density value is used by HWComposer to set a scale factor
for screens which it passes to Mir. This value is 480 on the Nexus 5
and 360 on the Nexus 7. The default value for the FP2 is 360. This
causes the FP2 to look like an "odd duck" with the new QtQuick scaling
settings we've added, with things being scaled far too large on every
other device.