### PR TITLE
FP2-1785:Change headphone left and right channel.

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -879,8 +879,8 @@
         <ctl name="SLIM RX1 MUX" value="AIF1_PB" />
         <ctl name="SLIM RX2 MUX" value="AIF1_PB" />
         <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX1 MIX1 INP1" value="RX1" />
-        <ctl name="RX2 MIX1 INP1" value="RX2" />
+        <ctl name="RX1 MIX1 INP1" value="RX2" />
+        <ctl name="RX2 MIX1 INP1" value="RX1" />
         <ctl name="CLASS_H_DSM MUX" value="DSM_HPHL_RX1" />
         <ctl name="HPHL DAC Switch" value="1" />
         <ctl name="COMP1 Switch" value="1" />


### PR DESCRIPTION
Change headphone left and right channel.

This is cherry-picked from the Fairphone's tree. It simply swaps output for `headphones` path in `mixer_paths.xml`. This fixes ubports/ubuntu-touch#563.